### PR TITLE
DVORAK Keymap complete

### DIFF
--- a/config/sofle_ergomech.conf
+++ b/config/sofle_ergomech.conf
@@ -15,3 +15,6 @@ CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
 # By default toggling the underglow on and off also toggles external power
 # on and off. This also causes the display to turn off.
 # CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER=n
+
+# Mouse stuff
+CONFIG_ZMK_MOUSE=y

--- a/config/sofle_ergomech.keymap
+++ b/config/sofle_ergomech.keymap
@@ -12,8 +12,8 @@
 #include <dt-bindings/zmk/mouse.h>
 
 #define BASE 0
-#define LOWER 1
-#define RAISE 2
+#define RAISE 1
+#define LOWER 2
 #define ADJUST 3
 
 / {
@@ -96,20 +96,20 @@
 
         adjust_layer {
             label = "adjust";
-// ----------------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------------------
 // | BTCLR  |  BT1    |  BT2    |   BT3   |   BT4   |   BT5   |                      |      |      |       |      |       |       |
 // | EXTPWR | RGB_HUD | RGB_HUI | RGB_SAD | RGB_SAI | RGB_EFF |                      |      |      |       |      |       |       |
 // |        | RGB_BRD | RGB_BRI |         |         |         |                      |      |      |       |      |       |       |
 // |        |         |         |         |         |         | RGB_TOG | |          |      |      |       |      |       |       |
-//                    |         |         |         |         |         | | SYSRESET |      |      |       |      |
+//                    |         |         |         |         |         | |          |      |      |       |      |
 //                                                                    HAT:| LCLK     | LEFT |  UP  |  DOWN | RIGHT|
             bindings = <
-&bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                                &none &none &none &none &none &none
-&ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                             &none &none &none &none &none &none
-&none             &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                       &none &none &none &none &none &none
-&none             &none           &none           &none           &none           &none            &rgb_ug RGB_TOG            &none &none &none &none &none &none
-                                  &none           &none           &none           &none            &none           &sys_reset &none &none &none &none
-                                                                                                                   &mkp LCLK  &kp LEFT  &kp UP    &kp DOWN &kp RIGHT
+&bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                                &none    &none  &none    &none     &none &none
+&ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                             &none    &none  &none    &none     &none &none
+&none             &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                       &none    &none  &none    &none     &none &none
+&none             &none           &none           &none           &none           &none            &rgb_ug RGB_TOG            &none    &none  &none    &none     &none &none
+                                  &none           &none           &none           &none            &none           &none      &none    &none  &none    &none
+                                                                                                                   &mkp LCLK  &kp LEFT &kp UP &kp DOWN &kp RIGHT
             >;
         };
 

--- a/config/sofle_ergomech.keymap
+++ b/config/sofle_ergomech.keymap
@@ -38,14 +38,14 @@
 // |  CTRL |   A   |    O    |   E    |   U     |   I      |                     |   D     |    H    |   T     |  N     |   S    |   -   |
 // | SHIFT |   ;   |    Q    |   J    |   K     |   X      |  ENTER  |  |        |   B     |    M    |   W     |  V     |   V    |   \   |
 //                 |   GUI   |  ALT   |  LOWER  |  RAISE   |  SPACE  |  |  SPACE |  LEFT   |    UP   |   DOWN  | RIGHT  |
-//                                                                  HAT:|  ENTER |  LEFT   |    UP   |   DOWN  | RIGHT  |
+//                                                                  HAT:|  LCLK  |  LEFT   |    UP   |   DOWN  | RIGHT  |
             bindings = <
 &kp GRAVE &kp N1   &kp N2    &kp N3   &kp N4    &kp N5                           &kp N6    &kp N7    &kp N8    &kp N9   &kp N0   &kp EQUAL
 &kp TAB   &kp APOS &kp COMMA &kp DOT  &kp P     &kp Y                            &kp F     &kp G     &kp C     &kp R    &kp L    &kp FSLH
 &kp LCTRL &kp A    &kp O     &kp E    &kp U     &kp I                            &kp D     &kp H     &kp T     &kp N    &kp S    &kp MINUS
 &kp LSHFT &kp SEMI &kp Q     &kp J    &kp K     &kp X      &kp ENTER             &kp B     &kp M     &kp W     &kp V    &kp V    &kp BSLH
                    &kp LGUI  &kp LALT &mo LOWER &mo RAISE  &kp SPACE  &kp SPACE  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
-                                                                      &kp ENTER  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
+                                                                      &mkp LCLK  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
             >;
 
             sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
@@ -58,15 +58,15 @@
 // |       |   INS      |   PSCR     |   GUI      |   CAPS     |            |                 |  BSPC   |  HOME   |  UP    |   END   |  PG_UP  | C_MUTE |
 // |       |   ALT      |   CTRL     |   SHIFT    |            |            |                 |  RET    |  LEFT   | DOWN   |  RIGHT  |  PG_DN  |C_VOL_UP|
 // |       |   UNDO     |   CUT      |   COPY     |   PASTE    |            |      |  |       |  ENTER  |         |        |         |         |C_VOL_DN|
-//                      |            |            |            |            | SPACE|  | SPACE |         |         |        |         |
-//                                                                                HAT:| ENTER |  LEFT   |   UP    |  DOWN  |  RIGHT  |
+//                      |            |            |            |            | SPACE|  | LCLK  |         |         |        |         |
+//                                                                                HAT:| LCLK  |  LEFT   |   UP    |  DOWN  |  RIGHT  |
             bindings = <   
 &bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4                   &none     &none     &none    &kp LBKT  &kp RBKT  &kp DEL
 &none      &kp INS      &kp PSCRN    &kp K_CMENU  &kp CAPS     &none                          &kp BSPC  &kp HOME  &kp UP   &kp END   &kp PG_UP &kp C_MUTE
 &none      &kp LALT     &kp LCTRL    &kp LSHFT    &none        &none                          &kp RET   &kp LEFT  &kp DOWN &kp RIGHT &kp PG_DN &kp C_VOL_UP
 &none      &kp K_UNDO   &kp K_CUT    &kp K_COPY   &kp K_PASTE  &none        &none             &kp ENTER &none     &none    &none     &none     &kp C_VOL_DN
-                        &trans       &trans       &trans       &trans       &trans  &trans    &trans    &none     &none    &none 
-                                                                                    &kp ENTER &kp LEFT  &kp UP    &kp DOWN &kp RIGHT
+                        &trans       &trans       &trans       &trans       &trans  &mkp LCLK &trans    &none     &none    &none 
+                                                                                    &mkp LCLK &kp LEFT  &kp UP    &kp DOWN &kp RIGHT
             >;
 
             sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
@@ -81,14 +81,14 @@
 // |       |         |         |          |           |  RET     |                  |  RET    | LEFT   | DOWN   |  RIGHT  |  PG_DN  |  DEL  |
 // |       | K_UNDO  |  K_CUT  |  K_COPY  | K_PASTE   |  ENTER   |       |  |       |  ENTER  |        |        |         |         |       |
 //                   |         |          |           |          | SPACE |  | SPACE |         |        |        |         |
-//                                                                      HAT:| ENTER |  LEFT   |  UP    |  DOWN  |  RIGHT  |
+//                                                                      HAT:| LCLK  |  LEFT   |  UP    |  DOWN  |  RIGHT  |
             bindings = < 
 &none     &kp F1     &kp F2    &kp F3     &kp F4      &kp F5                        &kp F6    &kp F7   &kp F8   &kp F9    &kp F10   &kp F11
 &none     &none      &none     &none      &none       &kp BSPC                      &kp BSPC  &kp HOME &kp UP   &kp END   &kp PG_UP &kp F12
 &none     &none      &none     &none      &none       &kp RET                       &kp RET   &kp LEFT &kp DOWN &kp RIGHT &kp PG_DN &kp DEL
 &none     &kp K_UNDO &kp K_CUT &kp K_COPY &kp K_PASTE &kp ENTER  &none              &kp ENTER &none    &none    &none     &none     &none
                      &trans    &trans     &trans      &trans     &trans   &trans    &trans    &trans   &trans   &trans
-                                                                          &kp ENTER &kp LEFT  &kp UP   &kp DOWN &kp RIGHT
+                                                                          &mkp LCLK &kp LEFT  &kp UP   &kp DOWN &kp RIGHT
             >;
 
             sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
@@ -102,14 +102,14 @@
 // |        | RGB_BRD | RGB_BRI |         |         |         |                      |      |      |       |      |       |       |
 // |        |         |         |         |         |         | RGB_TOG | |          |      |      |       |      |       |       |
 //                    |         |         |         |         |         | |          |      |      |       |      |
-//                                                                    HAT:| ENTER    | LEFT |  UP  |  DOWN | RIGHT|
+//                                                                    HAT:| LCLK     | LEFT |  UP  |  DOWN | RIGHT|
             bindings = <
 &bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                                &none    &none  &none    &none     &none &none
 &ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                             &none    &none  &none    &none     &none &none
 &none             &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                       &none    &none  &none    &none     &none &none
 &none             &none           &none           &none           &none           &none            &rgb_ug RGB_TOG            &none    &none  &none    &none     &none &none
                                   &none           &none           &none           &none            &none           &none      &none    &none  &none    &none
-                                                                                                                   &kp ENTER  &kp LEFT &kp UP &kp DOWN &kp RIGHT
+                                                                                                                   &mkp LCLK  &kp LEFT &kp UP &kp DOWN &kp RIGHT
             >;
         };
 

--- a/config/sofle_ergomech.keymap
+++ b/config/sofle_ergomech.keymap
@@ -67,7 +67,7 @@
 &trans     &kp C_AC_UNDO &kp C_AC_CUT &kp C_AC_COPY &kp C_AC_PASTE &none        &none             &kp ENTER &mkp LCLK &mkp MCLK &mkp RCLK &none     &kp C_VOL_DN
                          &trans       &trans        &trans         &trans       &trans  &trans    &trans    &trans    &trans    &trans
                                                                                         &mkp LCLK &kp DOWN  &kp UP    &kp RIGHT &kp LEFT
-            >;c
+            >;
 
             sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
         };

--- a/config/sofle_ergomech.keymap
+++ b/config/sofle_ergomech.keymap
@@ -9,7 +9,7 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/rgb.h>
 #include <dt-bindings/zmk/ext_power.h>
-#include <dt-bindings/zmk/mouse.h>
+//#include <dt-bindings/zmk/mouse.h>
 
 #define BASE 0
 #define RAISE 1
@@ -36,16 +36,16 @@
 // |   `   |   1   |    2    |   3    |   4     |   5      |                     |   6     |    7    |   8     |  9     |   0    |   =   |
 // |  TAB  |   '   |    ,    |   .    |   P     |   Y      |                     |   F     |    G    |   C     |  R     |   L    |   /   |
 // |  CTRL |   A   |    O    |   E    |   U     |   I      |                     |   D     |    H    |   T     |  N     |   S    |   -   |
-// | SHIFT |   ;   |    Q    |   J    |   K     |   X      |  LCLK   |  |        |   B     |    M    |   W     |  V     |   V    |   \   |
+// | SHIFT |   ;   |    Q    |   J    |   K     |   X      |  ENTER  |  |        |   B     |    M    |   W     |  V     |   V    |   \   |
 //                 |   GUI   |  ALT   |  LOWER  |  RAISE   |  SPACE  |  |  SPACE |  LEFT   |    UP   |   DOWN  | RIGHT  |
-//                                                                  HAT:|  LCLK  |  LEFT   |    UP   |   DOWN  | RIGHT  |
+//                                                                  HAT:|  ENTER |  LEFT   |    UP   |   DOWN  | RIGHT  |
             bindings = <
 &kp GRAVE &kp N1   &kp N2    &kp N3   &kp N4    &kp N5                           &kp N6    &kp N7    &kp N8    &kp N9   &kp N0   &kp EQUAL
 &kp TAB   &kp APOS &kp COMMA &kp DOT  &kp P     &kp Y                            &kp F     &kp G     &kp C     &kp R    &kp L    &kp FSLH
 &kp CTRL  &kp A    &kp O     &kp E    &kp U     &kp I                            &kp D     &kp H     &kp T     &kp N    &kp S    &kp MINUS
-&kp LSHFT &kp SEMI &kp Q     &kp J    &kp K     &kp X      &mkp LCLK             &kp B     &kp M     &kp W     &kp V    &kp V    &kp BSLH
+&kp LSHFT &kp SEMI &kp Q     &kp J    &kp K     &kp X      &kp ENTER             &kp B     &kp M     &kp W     &kp V    &kp V    &kp BSLH
                    &kp LGUI  &kp LALT &mo LOWER &mo RAISE  &kp SPACE  &kp SPACE  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
-                                                                      &mkp LCLK  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
+                                                                      &kp ENTER  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
             >;
 
             sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
@@ -60,14 +60,14 @@
 // |       |         |         |          |           |  RET     |                  |  RET    | LEFT   | DOWN   |  RIGHT  |  PG_DN  |  DEL  |
 // |       | K_UNDO  |  K_CUT  |  K_COPY  | K_PASTE   |  ENTER   |       |  |       |  ENTER  |        |        |         |         |       |
 //                   |         |          |           |          | SPACE |  | SPACE |         |        |        |         |
-//                                                                      HAT:| LCLK  |  LEFT   |  UP    |  DOWN  |  RIGHT  |
+//                                                                      HAT:| ENTER |  LEFT   |  UP    |  DOWN  |  RIGHT  |
             bindings = < 
 &none     &kp F1     &kp F2    &kp F3     &kp F4      &kp F5                        &kp F6    &kp F7   &kp F8   &kp F9    &kp F10   &kp F11
 &none     &none      &none     &none      &none       &kp BSPC                      &kp BSPC  &kp HOME &kp UP   &kp END   &kp PG_UP &kp F12
 &none     &none      &none     &none      &none       &kp RET                       &kp RET   &kp LEFT &kp DOWN &kp RIGHT &kp PG_DN &kp DEL
 &none     &kp K_UNDO &kp K_CUT &kp K_COPY &kp K_PASTE &kp ENTER  &none              &kp ENTER &none    &none    &none     &none     &none
                      &trans    &trans     &trans      &trans     &trans   &trans    &trans    &trans   &trans   &trans
-                                                                          &mkp LCLK &kp LEFT  &kp UP   &kp DOWN &kp RIGHT
+                                                                          &kp ENTER &kp LEFT  &kp UP   &kp DOWN &kp RIGHT
             >;
 
             sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
@@ -81,14 +81,14 @@
 // |       |   ALT      |   CTRL     |   SHIFT    |            |            |                 |  RET    |  LEFT   | DOWN   |  RIGHT  | PG_DN  |C_VOL_UP|
 // |       |   UNDO     |   CUT      |   COPY     |   PASTE    |            |      |  |       |  ENTER  |         |        |         |        |C_VOL_DN|
 //                      |            |            |            |            | SPACE|  | SPACE |         |         |        |         |
-//                                                                                HAT:| LCLK  |  LEFT   |   UP    |  DOWN  |  RIGHT  |
+//                                                                                HAT:| ENTER |  LEFT   |   UP    |  DOWN  |  RIGHT  |
             bindings = <   
 &bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4                   &none     &none     &none    &kp LBKT  &kp RBKT &kp DEL
 &none      &kp INS      &kp PSCRN    &kp K_CMENU  &CAPS        &none                          &kp PG_UP &trans    &trans   &trans    &trans   &kp C_MUTE
 &none      &kp LALT     &kp LCTRL    &kp LSHFT    &none        &none                          &kp PG_DN &trans    &trans   &trans    &trans   &kp C_VOL_UP
 &none      &kp K_UNDO   &kp K_CUT    &kp K_COPY   &kp K_PASTE  &none        &none             &trans    &none     &none    &none     &none    &kp C_VOL_DN
                         &trans       &trans       &trans       &trans       &trans  &trans    &trans    &none     &none    &none 
-                                                                                    &mkp LCLK &kp LEFT  &kp UP    &kp DOWN &kp RIGHT
+                                                                                    &kp ENTER &kp LEFT  &kp UP    &kp DOWN &kp RIGHT
             >;
 
             sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
@@ -102,14 +102,14 @@
 // |        | RGB_BRD | RGB_BRI |         |         |         |                      |      |      |       |      |       |       |
 // |        |         |         |         |         |         | RGB_TOG | |          |      |      |       |      |       |       |
 //                    |         |         |         |         |         | |          |      |      |       |      |
-//                                                                    HAT:| LCLK     | LEFT |  UP  |  DOWN | RIGHT|
+//                                                                    HAT:| ENTER    | LEFT |  UP  |  DOWN | RIGHT|
             bindings = <
 &bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                                &none    &none  &none    &none     &none &none
 &ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                             &none    &none  &none    &none     &none &none
 &none             &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                       &none    &none  &none    &none     &none &none
 &none             &none           &none           &none           &none           &none            &rgb_ug RGB_TOG            &none    &none  &none    &none     &none &none
                                   &none           &none           &none           &none            &none           &none      &none    &none  &none    &none
-                                                                                                                   &mkp LCLK  &kp LEFT &kp UP &kp DOWN &kp RIGHT
+                                                                                                                   &kp ENTER  &kp LEFT &kp UP &kp DOWN &kp RIGHT
             >;
         };
 

--- a/config/sofle_ergomech.keymap
+++ b/config/sofle_ergomech.keymap
@@ -9,6 +9,7 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/rgb.h>
 #include <dt-bindings/zmk/ext_power.h>
+#include <dt-bindings/zmk/mouse.h>
 
 #define BASE 0
 #define LOWER 1
@@ -31,80 +32,84 @@
 
         default_layer {
             label = "default";
-// ------------------------------------------------------------------------------------------------------------
-// |   `   |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   |       |
-// |  ESC  |  Q  |  W  |  E   |  R   |  T   |                   |  Y   |  U    |  I    |  O   |   P   | BKSPC |
-// |  TAB  |  A  |  S  |  D   |  F   |  G   |                   |  H   |  J    |  K    |  L   |   ;   |   '   |
-// | SHIFT |  Z  |  X  |  C   |  V   |  B   |  MUTE  |  |       |  N   |  M    |  ,    |  .   |   /   | SHIFT |
-//               | GUI | ALT  | CTRL | LOWER|  ENTER |  | SPACE | RAISE| CTRL  | ALT   | GUI  |
+// ---------------------------------------------------------------------------------------------------------------------------------------
+// |   `   |   1   |    2    |   3    |   4     |   5      |                     |   6     |    7    |   8     |  9     |   0    |   =   |
+// |  TAB  |   '   |    ,    |   .    |   P     |   Y      |                     |   F     |    G    |   C     |  R     |   L    |   /   |
+// |  CTRL |   A   |    O    |   E    |   U     |   I      |                     |   D     |    H    |   T     |  N     |   S    |   -   |
+// | SHIFT |   ;   |    Q    |   J    |   K     |   X      |  LCLK   |  |        |   B     |    M    |   W     |  V     |   V    |   \   |
+//                 |   GUI   |  ALT   |  LOWER  |  RAISE   |  SPACE  |  |  SPACE |  LEFT   |    UP   |   DOWN  | RIGHT  |
+//                                                                  HAT:|  LCLK  |  LEFT   |    UP   |   DOWN  | RIGHT  |
             bindings = <
-&kp GRAVE &kp N1 &kp N2   &kp N3   &kp N4    &kp N5                           &kp N6 &kp N7    &kp N8    &kp N9   &kp N0   &none
-&kp ESC   &kp Q  &kp W    &kp E    &kp R     &kp T                            &kp Y  &kp U     &kp I     &kp O    &kp P    &kp BSPC
-&kp TAB   &kp A  &kp S    &kp D    &kp F     &kp G                            &kp H  &kp J     &kp K     &kp L    &kp SEMI &kp SQT
-&kp LSHFT &kp Z  &kp X    &kp C    &kp V     &kp B      &kp C_MUTE            &kp N  &kp M     &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
-                 &kp LGUI &kp LALT &kp LCTRL &mo LOWER  &kp RET    &kp SPACE  &mo RAISE  &kp RCTRL &kp RALT  &kp RGUI
-                                                                   &kp A      &kp B  &kp C &kp D  &kp E
+&kp GRAVE &kp N1   &kp N2    &kp N3   &kp N4    &kp N5                           &kp N6    &kp N7    &kp N8    &kp N9   &kp N0   &kp EQUAL
+&kp TAB   &kp APOS &kp COMMA &kp DOT  &kp P     &kp Y                            &kp F     &kp G     &kp C     &kp R    &kp L    &kp FSLH
+&kp CTRL  &kp A    &kp O     &kp E    &kp U     &kp I                            &kp D     &kp H     &kp T     &kp N    &kp S    &kp MINUS
+&kp LSHFT &kp SEMI &kp Q     &kp J    &kp K     &kp X      &mkp LCLK             &kp B     &kp M     &kp W     &kp V    &kp V    &kp BSLH
+                   &kp LGUI  &kp LALT &mo LOWER &mo RAISE  &kp SPACE  &kp SPACE  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
+                                                                      &mkp LCLK  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
             >;
 
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
-        };
-
-        lower_layer {
-            label = "lower";
-// TODO: Some binds are waiting for shifted keycode support.
-// ------------------------------------------------------------------------------------------------------------
-// |       |  F1 |  F2 |  F3  |  F4  |  F5  |                   |  F6  |  F7   |  F8   |  F9  |  F10  |  F11  |
-// |   `   |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   |  F12  |
-// |       |  !  |  @  |  #   |  $   |  %   |                   |  ^   |  &    |  *    |  (   |   )   |   |   |
-// |       |  =  |  -  |  +   |  {   |  }   |        |  |       |  [   |  ]    |  ;    |  :   |   \   |       |
-//               |     |      |      |      |        |  |       |      |       |       |      |
-            bindings = <
-&trans    &kp F1    &kp F2    &kp F3      &kp F4    &kp F5                    &kp F6    &kp F7   &kp F8          &kp F9    &kp F10   &kp F11
-&kp GRAVE &kp N1    &kp N2    &kp N3      &kp N4    &kp N5                    &kp N6    &kp N7   &kp N8          &kp N9    &kp N0    &kp F12
-&trans    &kp EXCL  &kp AT    &kp HASH    &kp DLLR  &kp PRCNT                 &kp CARET &kp AMPS &kp KP_MULTIPLY &kp LPAR  &kp RPAR  &kp PIPE
-&trans    &kp EQUAL &kp MINUS &kp KP_PLUS &kp LBRC  &kp RBRC   &trans         &kp LBKT  &kp RBKT &kp SEMI        &kp COLON &kp BSLH  &trans
-                    &trans    &trans      &trans    &trans     &trans &trans  &trans    &trans   &trans          &trans
-                                                                      &kp A      &kp B  &kp C &kp D  &kp E
-            >;
-
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+            sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
         };
 
         raise_layer {
             label = "raise";
-// ------------------------------------------------------------------------------------------------------------
-// | BTCLR | BT1  | BT2  |  BT3  |  BT4  |  BT5 |                |      |      |       |      |       |       |
-// |       | INS  | PSCR | GUI   |       |      |                | PGUP |      |   ^   |      |       |       |
-// |       | ALT  | CTRL | SHIFT |       | CAPS |                | PGDN |   <- |   v   |  ->  |  DEL  | BKSPC |
-// |       | UNDO | CUT  | COPY  | PASTE |      |      |  |      |      |      |       |      |       |       |
-//                |      |       |       |      |      |  |      |      |      |       |      |
-            bindings = <
-&bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4                  &trans    &trans    &trans   &trans    &trans  &trans
-&trans     &kp INS      &kp PSCRN    &kp K_CMENU  &trans       &trans                        &kp PG_UP &trans    &kp UP   &trans    &kp N0  &trans
-&trans     &kp LALT     &kp LCTRL    &kp LSHFT    &trans       &kp CLCK                      &kp PG_DN &kp LEFT  &kp DOWN &kp RIGHT &kp DEL &kp BSPC
-&trans     &kp K_UNDO   &kp K_CUT    &kp K_COPY   &kp K_PASTE  &trans        &trans          &trans    &trans    &trans   &trans    &trans  &trans
-                        &trans       &trans       &trans       &trans        &trans  &trans  &trans    &trans    &trans   &trans
-                                                                                     &kp A      &kp B  &kp C &kp D  &kp E
+// TODO: Some binds are waiting for shifted keycode support.
+// ------------------------------------------------------------------------------------------------------------------------------------------
+// |       |   F1    |   F2    |    F3    |   F4      |   F5     |                  |   F6    |  F7    |  F8    |   F9    |   F10   |  F11  |
+// |       |         |         |          |           |  BSPC    |                  |  BSPC   | HOME   |  UP    |   END   |  PG_UP  |  F12  |
+// |       |         |         |          |           |  RET     |                  |  RET    | LEFT   | DOWN   |  RIGHT  |  PG_DN  |  DEL  |
+// |       | K_UNDO  |  K_CUT  |  K_COPY  | K_PASTE   |  ENTER   |       |  |       |  ENTER  |        |        |         |         |       |
+//                   |         |          |           |          | SPACE |  | SPACE |         |        |        |         |
+//                                                                      HAT:| LCLK  |  LEFT   |  UP    |  DOWN  |  RIGHT  |
+            bindings = < 
+&none     &kp F1     &kp F2    &kp F3     &kp F4      &kp F5                        &kp F6    &kp F7   &kp F8   &kp F9    &kp F10   &kp F11
+&none     &none      &none     &none      &none       &kp BSPC                      &kp BSPC  &kp HOME &kp UP   &kp END   &kp PG_UP &kp F12
+&none     &none      &none     &none      &none       &kp RET                       &kp RET   &kp LEFT &kp DOWN &kp RIGHT &kp PG_DN &kp DEL
+&none     &kp K_UNDO &kp K_CUT &kp K_COPY &kp K_PASTE &kp ENTER  &none              &kp ENTER &none    &none    &none     &none     &none
+                     &trans    &trans     &trans      &trans     &trans   &trans    &trans    &trans   &trans   &trans
+                                                                          &mkp LCLK &kp LEFT  &kp UP   &kp DOWN &kp RIGHT
             >;
 
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+            sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
+        };
+
+        lower_layer {
+            label = "lower";
+// -----------------------------------------------------------------------------------------------------------------------------------------------------
+// | BTCLR |   BT1      |   BT2      |    BT3     |    BT4     |    BT5     |                 |         |         |        |  LBKT   | RBKT   |  DEL   |
+// |       |   INS      |   PSCR     |   GUI      |   CAPS     |            |                 |  BSPC   |  HOME   |  UP    |   END   | PG_UP  | C_MUTE |
+// |       |   ALT      |   CTRL     |   SHIFT    |            |            |                 |  RET    |  LEFT   | DOWN   |  RIGHT  | PG_DN  |C_VOL_UP|
+// |       |   UNDO     |   CUT      |   COPY     |   PASTE    |            |      |  |       |  ENTER  |         |        |         |        |C_VOL_DN|
+//                      |            |            |            |            | SPACE|  | SPACE |         |         |        |         |
+//                                                                                HAT:| LCLK  |  LEFT   |   UP    |  DOWN  |  RIGHT  |
+            bindings = <   
+&bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4                   &none     &none     &none    &kp LBKT  &kp RBKT &kp DEL
+&none      &kp INS      &kp PSCRN    &kp K_CMENU  &CAPS        &none                          &kp PG_UP &trans    &trans   &trans    &trans   &kp C_MUTE
+&none      &kp LALT     &kp LCTRL    &kp LSHFT    &none        &none                          &kp PG_DN &trans    &trans   &trans    &trans   &kp C_VOL_UP
+&none      &kp K_UNDO   &kp K_CUT    &kp K_COPY   &kp K_PASTE  &none        &none             &trans    &none     &none    &none     &none    &kp C_VOL_DN
+                        &trans       &trans       &trans       &trans       &trans  &trans    &trans    &none     &none    &none 
+                                                                                    &mkp LCLK &kp LEFT  &kp UP    &kp DOWN &kp RIGHT
+            >;
+
+            sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
         };
 
         adjust_layer {
-// ----------------------------------------------------------------------------------------------------------------------------
-// | BTCLR  |  BT1    |  BT2    |   BT3   |   BT4   |   BT5   |                  |      |      |       |      |       |       |
-// | EXTPWR | RGB_HUD | RGB_HUI | RGB_SAD | RGB_SAI | RGB_EFF |                  |      |      |       |      |       |       |
-// |        | RGB_BRD | RGB_BRI |         |         |         |                  |      |      |       |      |       |       |
-// |        |         |         |         |         |         | RGB_TOG | |      |      |      |       |      |       |       |
-//                    |         |         |         |         |         | |      |      |      |       |      |
             label = "adjust";
+// ----------------------------------------------------------------------------------------------------------------------------
+// | BTCLR  |  BT1    |  BT2    |   BT3   |   BT4   |   BT5   |                      |      |      |       |      |       |       |
+// | EXTPWR | RGB_HUD | RGB_HUI | RGB_SAD | RGB_SAI | RGB_EFF |                      |      |      |       |      |       |       |
+// |        | RGB_BRD | RGB_BRI |         |         |         |                      |      |      |       |      |       |       |
+// |        |         |         |         |         |         | RGB_TOG | |          |      |      |       |      |       |       |
+//                    |         |         |         |         |         | | SYSRESET |      |      |       |      |
+//                                                                    HAT:| LCLK     | LEFT |  UP  |  DOWN | RIGHT|
             bindings = <
-&bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                            &none &none &none &none &none &none
-&ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                         &none &none &none &none &none &none
-&none             &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                   &none &none &none &none &none &none
-&none             &none           &none           &none           &none           &none            &rgb_ug RGB_TOG        &none &none &none &none &none &none
-                                  &none           &none           &none           &none            &none           &none  &none &none &none &none
-                                                                                                                    &kp A      &kp B  &kp C &kp D  &kp E
+&bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                                &none &none &none &none &none &none
+&ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                             &none &none &none &none &none &none
+&none             &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                       &none &none &none &none &none &none
+&none             &none           &none           &none           &none           &none            &rgb_ug RGB_TOG            &none &none &none &none &none &none
+                                  &none           &none           &none           &none            &none           &sys_reset &none &none &none &none
+                                                                                                                   &mkp LCLK  &kp LEFT  &kp UP    &kp DOWN &kp RIGHT
             >;
         };
 

--- a/config/sofle_ergomech.keymap
+++ b/config/sofle_ergomech.keymap
@@ -51,23 +51,23 @@
 
         lower_layer {
             label = "lower";
-// TODO: Some binds are waiting for shifted keycode support.
-// ------------------------------------------------------------------------------------------------------------
-// |       |  F1 |  F2 |  F3  |  F4  |  F5  |                   |  F6  |  F7   |  F8   |  F9  |  F10  |  F11  |
-// |   `   |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   |  F12  |
-// |       |  !  |  @  |  #   |  $   |  %   |                   |  ^   |  &    |  *    |  (   |   )   |   |   |
-// |       |  =  |  -  |  +   |  {   |  }   |        |  |       |  [   |  ]    |  ;    |  :   |   \   |       |
-//               |     |      |      |      |        |  |       |      |       |       |      |
-            bindings = <
-&trans    &kp F1    &kp F2    &kp F3      &kp F4    &kp F5                    &kp F6    &kp F7   &kp F8          &kp F9    &kp F10   &kp F11
-&kp GRAVE &kp N1    &kp N2    &kp N3      &kp N4    &kp N5                    &kp N6    &kp N7   &kp N8          &kp N9    &kp N0    &kp F12
-&trans    &kp EXCL  &kp AT    &kp HASH    &kp DLLR  &kp PRCNT                 &kp CARET &kp AMPS &kp KP_MULTIPLY &kp LPAR  &kp RPAR  &kp PIPE
-&trans    &kp EQUAL &kp MINUS &kp KP_PLUS &kp LBRC  &kp RBRC   &trans         &kp LBKT  &kp RBKT &kp SEMI        &kp COLON &kp BSLH  &trans
-                    &trans    &trans      &trans    &trans     &trans &trans  &trans    &trans   &trans          &trans
-                                                                      &kp A      &kp B  &kp C &kp D  &kp E
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
+// | BTCLR |   BT1      |   BT2      |    BT3     |    BT4     |    BT5     |                 |         |         |        |  LBKT   |  RBKT   |  DEL   |
+// |       |   INS      |   PSCR     |   GUI      |   CAPS     |            |                 |  BSPC   |  HOME   |  UP    |   END   |  PG_UP  | C_MUTE |
+// |       |   ALT      |   CTRL     |   SHIFT    |            |            |                 |  RET    |  LEFT   | DOWN   |  RIGHT  |  PG_DN  |C_VOL_UP|
+// |       |   UNDO     |   CUT      |   COPY     |   PASTE    |            |      |  |       |  ENTER  |         |        |         |         |C_VOL_DN|
+//                      |            |            |            |            | SPACE|  | SPACE |         |         |        |         |
+//                                                                                HAT:| ENTER |  LEFT   |   UP    |  DOWN  |  RIGHT  |
+            bindings = <   
+&bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4                   &none     &none     &none    &kp LBKT  &kp RBKT  &kp DEL
+&none      &kp INS      &kp PSCRN    &kp K_CMENU  &kp CAPS     &none                          &kp BSPC  &kp HOME  &kp UP   &kp END   &kp PG_UP &kp C_MUTE
+&none      &kp LALT     &kp LCTRL    &kp LSHFT    &none        &none                          &kp RET   &kp LEFT  &kp DOWN &kp RIGHT &kp PG_DN &kp C_VOL_UP
+&none      &kp K_UNDO   &kp K_CUT    &kp K_COPY   &kp K_PASTE  &none        &none             &kp ENTER &none     &none    &none     &none     &kp C_VOL_DN
+                        &trans       &trans       &trans       &trans       &trans  &trans    &trans    &none     &none    &none 
+                                                                                    &kp ENTER &kp LEFT  &kp UP    &kp DOWN &kp RIGHT
             >;
 
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+            sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
         };
 
         raise_layer {

--- a/config/sofle_ergomech.keymap
+++ b/config/sofle_ergomech.keymap
@@ -9,6 +9,7 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/rgb.h>
 #include <dt-bindings/zmk/ext_power.h>
+#include <dt-bindings/zmk/mouse.h>
 
 #define BASE 0
 #define LOWER 1
@@ -41,7 +42,7 @@
             bindings = <
 &kp GRAVE &kp N1   &kp N2    &kp N3   &kp N4    &kp N5                           &kp N6    &kp N7    &kp N8    &kp N9   &kp N0   &kp EQUAL
 &kp TAB   &kp APOS &kp COMMA &kp DOT  &kp P     &kp Y                            &kp F     &kp G     &kp C     &kp R    &kp L    &kp FSLH
-&kp CTRL  &kp A    &kp O     &kp E    &kp U     &kp I                            &kp D     &kp H     &kp T     &kp N    &kp S    &kp MINUS
+&kp LCTRL &kp A    &kp O     &kp E    &kp U     &kp I                            &kp D     &kp H     &kp T     &kp N    &kp S    &kp MINUS
 &kp LSHFT &kp SEMI &kp Q     &kp J    &kp K     &kp X      &kp ENTER             &kp B     &kp M     &kp W     &kp V    &kp V    &kp BSLH
                    &kp LGUI  &kp LALT &mo LOWER &mo RAISE  &kp SPACE  &kp SPACE  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
                                                                       &kp ENTER  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT

--- a/config/sofle_ergomech.keymap
+++ b/config/sofle_ergomech.keymap
@@ -91,20 +91,21 @@
         };
 
         adjust_layer {
-// ----------------------------------------------------------------------------------------------------------------------------
-// | BTCLR  |  BT1    |  BT2    |   BT3   |   BT4   |   BT5   |                  |      |      |       |      |       |       |
-// | EXTPWR | RGB_HUD | RGB_HUI | RGB_SAD | RGB_SAI | RGB_EFF |                  |      |      |       |      |       |       |
-// |        | RGB_BRD | RGB_BRI |         |         |         |                  |      |      |       |      |       |       |
-// |        |         |         |         |         |         | RGB_TOG | |      |      |      |       |      |       |       |
-//                    |         |         |         |         |         | |      |      |      |       |      |
             label = "adjust";
+// --------------------------------------------------------------------------------------------------------------------------------
+// | BTCLR  |  BT1    |  BT2    |   BT3   |   BT4   |   BT5   |                      |      |      |       |      |       |       |
+// | EXTPWR | RGB_HUD | RGB_HUI | RGB_SAD | RGB_SAI | RGB_EFF |                      |      |      |       |      |       |       |
+// |        | RGB_BRD | RGB_BRI |         |         |         |                      |      |      |       |      |       |       |
+// |        |         |         |         |         |         | RGB_TOG | |          |      |      |       |      |       |       |
+//                    |         |         |         |         |         | |          |      |      |       |      |
+//                                                                    HAT:| ENTER    | LEFT |  UP  |  DOWN | RIGHT|
             bindings = <
-&bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                            &none &none &none &none &none &none
-&ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                         &none &none &none &none &none &none
-&none             &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                   &none &none &none &none &none &none
-&none             &none           &none           &none           &none           &none            &rgb_ug RGB_TOG        &none &none &none &none &none &none
-                                  &none           &none           &none           &none            &none           &none  &none &none &none &none
-                                                                                                                    &kp A      &kp B  &kp C &kp D  &kp E
+&bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                                &none    &none  &none    &none     &none &none
+&ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                             &none    &none  &none    &none     &none &none
+&none             &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                       &none    &none  &none    &none     &none &none
+&none             &none           &none           &none           &none           &none            &rgb_ug RGB_TOG            &none    &none  &none    &none     &none &none
+                                  &none           &none           &none           &none            &none           &none      &none    &none  &none    &none
+                                                                                                                   &kp ENTER  &kp LEFT &kp UP &kp DOWN &kp RIGHT
             >;
         };
 

--- a/config/sofle_ergomech.keymap
+++ b/config/sofle_ergomech.keymap
@@ -38,14 +38,14 @@
 // |  CTRL |   A   |    O    |   E    |   U     |   I      |                     |   D     |    H    |   T     |  N     |   S    |   -   |
 // | SHIFT |   ;   |    Q    |   J    |   K     |   X      |  ENTER  |  |        |   B     |    M    |   W     |  V     |   V    |   \   |
 //                 |   GUI   |  ALT   |  LOWER  |  RAISE   |  SPACE  |  |  SPACE |  LEFT   |    UP   |   DOWN  | RIGHT  |
-//                                                                  HAT:|  LCLK  |  LEFT   |    UP   |   DOWN  | RIGHT  |
+//                                                                  HAT:|  LCLK  |  DOWN   |    UP   |   RIGHT | LEFT   |
             bindings = <
 &kp GRAVE &kp N1   &kp N2    &kp N3   &kp N4    &kp N5                           &kp N6    &kp N7    &kp N8    &kp N9   &kp N0   &kp EQUAL
 &kp TAB   &kp APOS &kp COMMA &kp DOT  &kp P     &kp Y                            &kp F     &kp G     &kp C     &kp R    &kp L    &kp FSLH
 &kp LCTRL &kp A    &kp O     &kp E    &kp U     &kp I                            &kp D     &kp H     &kp T     &kp N    &kp S    &kp MINUS
 &kp LSHFT &kp SEMI &kp Q     &kp J    &kp K     &kp X      &kp ENTER             &kp B     &kp M     &kp W     &kp V    &kp V    &kp BSLH
                    &kp LGUI  &kp LALT &mo LOWER &mo RAISE  &kp SPACE  &kp SPACE  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
-                                                                      &mkp LCLK  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
+                                                                      &mkp LCLK  &kp DOWN  &kp UP    &kp RIGHT &kp LEFT
             >;
 
             sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
@@ -54,20 +54,20 @@
         lower_layer {
             label = "lower";
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
-// | BTCLR |   BT1      |   BT2      |    BT3     |    BT4     |    BT5     |                 |         |         |        |  LBKT   |  RBKT   |  DEL   |
-// |       |   INS      |   PSCR     |   GUI      |   CAPS     |            |                 |  BSPC   |  HOME   |  UP    |   END   |  PG_UP  | C_MUTE |
-// |       |   ALT      |   CTRL     |   SHIFT    |            |            |                 |  RET    |  LEFT   | DOWN   |  RIGHT  |  PG_DN  |C_VOL_UP|
-// |       |   UNDO     |   CUT      |   COPY     |   PASTE    |            |      |  |       |  ENTER  |         |        |         |         |C_VOL_DN|
-//                      |            |            |            |            | SPACE|  | LCLK  |         |         |        |         |
-//                                                                                HAT:| LCLK  |  LEFT   |   UP    |  DOWN  |  RIGHT  |
-            bindings = <   
-&bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4                   &none     &none     &none    &kp LBKT  &kp RBKT  &kp DEL
-&none      &kp INS      &kp PSCRN    &kp K_CMENU  &kp CAPS     &none                          &kp BSPC  &kp HOME  &kp UP   &kp END   &kp PG_UP &kp C_MUTE
-&none      &kp LALT     &kp LCTRL    &kp LSHFT    &none        &none                          &kp RET   &kp LEFT  &kp DOWN &kp RIGHT &kp PG_DN &kp C_VOL_UP
-&none      &kp K_UNDO   &kp K_CUT    &kp K_COPY   &kp K_PASTE  &none        &none             &kp ENTER &none     &none    &none     &none     &kp C_VOL_DN
-                        &trans       &trans       &trans       &trans       &trans  &mkp LCLK &trans    &none     &none    &none 
-                                                                                    &mkp LCLK &kp LEFT  &kp UP    &kp DOWN &kp RIGHT
-            >;
+// | BTCLR |   BT1       |   BT2      |    BT3      |    BT4       |    BT5     |                 |         |         |         |  LBKT   |  RBKT   |  DEL   |
+// |       |   INS       |   BACK     |   FWD       |   CAPS       |            |                 |  BSPC   |  HOME   |  UP     |   END   |  PG_UP  | C_MUTE |
+// |       |   ALT       |   CTRL     |   SHIFT     |              |            |                 |  RET    |  LEFT   |  DOWN   |  RIGHT  |  PG_DN  |C_VOL_UP|
+// |       |   UNDO      |   CUT      |   COPY      |   PASTE      |            |      |  |       |  ENTER  |  LCLK   |  MCLK   |  RCLK   |         |C_VOL_DN|
+//                       |            |             |              |            | SPACE|  | SPACE |         |         |         |         |
+//                                                                                    HAT:| LCLK  |  DOWN   |    UP   |  RIGHT  |  LEFT   |
+            bindings = <
+&bt BT_CLR &bt BT_SEL 0  &bt BT_SEL 1 &bt BT_SEL 2  &bt BT_SEL 3   &bt BT_SEL 4                   &none     &none     &none     &kp LBKT  &kp RBKT  &kp DEL
+&trans     &kp INS       &mkp MB4     &mkp MB5      &kp CAPS       &none                          &kp BSPC  &kp HOME  &kp UP    &kp END   &kp PG_UP &kp C_MUTE
+&trans     &kp LALT      &kp LCTRL    &kp LSHFT     &none          &none                          &kp RET   &kp LEFT  &kp DOWN  &kp RIGHT &kp PG_DN &kp C_VOL_UP
+&trans     &kp C_AC_UNDO &kp C_AC_CUT &kp C_AC_COPY &kp C_AC_PASTE &none        &none             &kp ENTER &mkp LCLK &mkp MCLK &mkp RCLK &none     &kp C_VOL_DN
+                         &trans       &trans        &trans         &trans       &trans  &trans    &trans    &trans    &trans    &trans
+                                                                                        &mkp LCLK &kp DOWN  &kp UP    &kp RIGHT &kp LEFT
+            >;c
 
             sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
         };
@@ -76,19 +76,19 @@
             label = "raise";
 // TODO: Some binds are waiting for shifted keycode support.
 // ------------------------------------------------------------------------------------------------------------------------------------------
-// |       |   F1    |   F2    |    F3    |   F4      |   F5     |                  |   F6    |  F7    |  F8    |   F9    |   F10   |  F11  |
-// |       |         |         |          |           |  BSPC    |                  |  BSPC   | HOME   |  UP    |   END   |  PG_UP  |  F12  |
-// |       |         |         |          |           |  RET     |                  |  RET    | LEFT   | DOWN   |  RIGHT  |  PG_DN  |  DEL  |
-// |       | K_UNDO  |  K_CUT  |  K_COPY  | K_PASTE   |  ENTER   |       |  |       |  ENTER  |        |        |         |         |       |
-//                   |         |          |           |          | SPACE |  | SPACE |         |        |        |         |
-//                                                                      HAT:| LCLK  |  LEFT   |  UP    |  DOWN  |  RIGHT  |
-            bindings = < 
-&none     &kp F1     &kp F2    &kp F3     &kp F4      &kp F5                        &kp F6    &kp F7   &kp F8   &kp F9    &kp F10   &kp F11
-&none     &none      &none     &none      &none       &kp BSPC                      &kp BSPC  &kp HOME &kp UP   &kp END   &kp PG_UP &kp F12
-&none     &none      &none     &none      &none       &kp RET                       &kp RET   &kp LEFT &kp DOWN &kp RIGHT &kp PG_DN &kp DEL
-&none     &kp K_UNDO &kp K_CUT &kp K_COPY &kp K_PASTE &kp ENTER  &none              &kp ENTER &none    &none    &none     &none     &none
-                     &trans    &trans     &trans      &trans     &trans   &trans    &trans    &trans   &trans   &trans
-                                                                          &mkp LCLK &kp LEFT  &kp UP   &kp DOWN &kp RIGHT
+// |  ESC  |   F1    |   F2    |    F3    |   F4      |   F5     |                  |   F6    |  F7    |  F8     |   F9    |   F10   |  F11  |
+// |       |         |         |          |           |  BSPC    |                  |  BSPC   | HOME   |  UP     |   END   |  PG_UP  |  F12  |
+// |       |         |         |          |           |  RET     |                  |  RET    | LEFT   | DOWN    |  RIGHT  |  PG_DN  |  DEL  |
+// |       |         |         |          |           |  ENTER   |       |  |       |         |        |         |         |         |       |
+//                   |         |          |           |          | SPACE |  | SPACE |         |        |         |         |
+//                                                                      HAT:| LCLK  |  DOWN   |   UP   |  RIGHT  |  LEFT   |
+            bindings = <
+&kp ESC   &kp F1     &kp F2    &kp F3     &kp F4      &kp F5                        &kp F6    &kp F7   &kp F8    &kp F9    &kp F10   &kp F11
+&trans    &none      &trans    &trans     &none       &kp BSPC                      &kp BSPC  &kp HOME &kp UP    &kp END   &kp PG_UP &kp F12
+&trans    &none      &none     &none      &none       &kp RET                       &kp RET   &kp LEFT &kp DOWN  &kp RIGHT &kp PG_DN &kp DEL
+&trans    &trans     &trans    &trans     &trans      &kp ENTER  &none              &trans    &trans   &trans    &trans    &none     &none
+                     &trans    &trans     &trans      &trans     &trans   &trans    &trans    &trans   &trans    &trans
+                                                                          &mkp LCLK &kp DOWN  &kp UP   &kp RIGHT &kp LEFT
             >;
 
             sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
@@ -102,14 +102,14 @@
 // |        | RGB_BRD | RGB_BRI |         |         |         |                      |      |      |       |      |       |       |
 // |        |         |         |         |         |         | RGB_TOG | |          |      |      |       |      |       |       |
 //                    |         |         |         |         |         | |          |      |      |       |      |
-//                                                                    HAT:| LCLK     | LEFT |  UP  |  DOWN | RIGHT|
+//                                                                    HAT:| LCLK     | DOWN |  UP  | RIGHT | LEFT |
             bindings = <
-&bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                                &none    &none  &none    &none     &none &none
-&ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                             &none    &none  &none    &none     &none &none
-&none             &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                       &none    &none  &none    &none     &none &none
-&none             &none           &none           &none           &none           &none            &rgb_ug RGB_TOG            &none    &none  &none    &none     &none &none
-                                  &none           &none           &none           &none            &none           &none      &none    &none  &none    &none
-                                                                                                                   &mkp LCLK  &kp LEFT &kp UP &kp DOWN &kp RIGHT
+&bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                                &none    &none  &none     &none     &none &none
+&ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                             &none    &none  &none     &none     &none &none
+&none             &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                       &none    &none  &none     &none     &none &none
+&none             &none           &none           &none           &none           &none            &rgb_ug RGB_TOG            &none    &none  &none     &none     &none &none
+                                  &none           &none           &none           &none            &none           &none      &none    &none  &none     &none
+                                                                                                                   &mkp LCLK  &kp DOWN &kp UP &kp RIGHT &kp LEFT
             >;
         };
 

--- a/config/sofle_ergomech.keymap
+++ b/config/sofle_ergomech.keymap
@@ -31,22 +31,23 @@
 
         default_layer {
             label = "default";
-// ------------------------------------------------------------------------------------------------------------
-// |   `   |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   |       |
-// |  ESC  |  Q  |  W  |  E   |  R   |  T   |                   |  Y   |  U    |  I    |  O   |   P   | BKSPC |
-// |  TAB  |  A  |  S  |  D   |  F   |  G   |                   |  H   |  J    |  K    |  L   |   ;   |   '   |
-// | SHIFT |  Z  |  X  |  C   |  V   |  B   |  MUTE  |  |       |  N   |  M    |  ,    |  .   |   /   | SHIFT |
-//               | GUI | ALT  | CTRL | LOWER|  ENTER |  | SPACE | RAISE| CTRL  | ALT   | GUI  |
+// ---------------------------------------------------------------------------------------------------------------------------------------
+// |   `   |   1   |    2    |   3    |   4     |   5      |                     |   6     |    7    |   8     |  9     |   0    |   =   |
+// |  TAB  |   '   |    ,    |   .    |   P     |   Y      |                     |   F     |    G    |   C     |  R     |   L    |   /   |
+// |  CTRL |   A   |    O    |   E    |   U     |   I      |                     |   D     |    H    |   T     |  N     |   S    |   -   |
+// | SHIFT |   ;   |    Q    |   J    |   K     |   X      |  ENTER  |  |        |   B     |    M    |   W     |  V     |   V    |   \   |
+//                 |   GUI   |  ALT   |  LOWER  |  RAISE   |  SPACE  |  |  SPACE |  LEFT   |    UP   |   DOWN  | RIGHT  |
+//                                                                  HAT:|  ENTER |  LEFT   |    UP   |   DOWN  | RIGHT  |
             bindings = <
-&kp GRAVE &kp N1 &kp N2   &kp N3   &kp N4    &kp N5                           &kp N6 &kp N7    &kp N8    &kp N9   &kp N0   &none
-&kp ESC   &kp Q  &kp W    &kp E    &kp R     &kp T                            &kp Y  &kp U     &kp I     &kp O    &kp P    &kp BSPC
-&kp TAB   &kp A  &kp S    &kp D    &kp F     &kp G                            &kp H  &kp J     &kp K     &kp L    &kp SEMI &kp SQT
-&kp LSHFT &kp Z  &kp X    &kp C    &kp V     &kp B      &kp C_MUTE            &kp N  &kp M     &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
-                 &kp LGUI &kp LALT &kp LCTRL &mo LOWER  &kp RET    &kp SPACE  &mo RAISE  &kp RCTRL &kp RALT  &kp RGUI
-                                                                   &kp A      &kp B  &kp C &kp D  &kp E
+&kp GRAVE &kp N1   &kp N2    &kp N3   &kp N4    &kp N5                           &kp N6    &kp N7    &kp N8    &kp N9   &kp N0   &kp EQUAL
+&kp TAB   &kp APOS &kp COMMA &kp DOT  &kp P     &kp Y                            &kp F     &kp G     &kp C     &kp R    &kp L    &kp FSLH
+&kp CTRL  &kp A    &kp O     &kp E    &kp U     &kp I                            &kp D     &kp H     &kp T     &kp N    &kp S    &kp MINUS
+&kp LSHFT &kp SEMI &kp Q     &kp J    &kp K     &kp X      &kp ENTER             &kp B     &kp M     &kp W     &kp V    &kp V    &kp BSLH
+                   &kp LGUI  &kp LALT &mo LOWER &mo RAISE  &kp SPACE  &kp SPACE  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
+                                                                      &kp ENTER  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
             >;
 
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+            sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
         };
 
         lower_layer {

--- a/config/sofle_ergomech.keymap
+++ b/config/sofle_ergomech.keymap
@@ -72,22 +72,24 @@
 
         raise_layer {
             label = "raise";
-// ------------------------------------------------------------------------------------------------------------
-// | BTCLR | BT1  | BT2  |  BT3  |  BT4  |  BT5 |                |      |      |       |      |       |       |
-// |       | INS  | PSCR | GUI   |       |      |                | PGUP |      |   ^   |      |       |       |
-// |       | ALT  | CTRL | SHIFT |       | CAPS |                | PGDN |   <- |   v   |  ->  |  DEL  | BKSPC |
-// |       | UNDO | CUT  | COPY  | PASTE |      |      |  |      |      |      |       |      |       |       |
-//                |      |       |       |      |      |  |      |      |      |       |      |
-            bindings = <
-&bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4                  &trans    &trans    &trans   &trans    &trans  &trans
-&trans     &kp INS      &kp PSCRN    &kp K_CMENU  &trans       &trans                        &kp PG_UP &trans    &kp UP   &trans    &kp N0  &trans
-&trans     &kp LALT     &kp LCTRL    &kp LSHFT    &trans       &kp CLCK                      &kp PG_DN &kp LEFT  &kp DOWN &kp RIGHT &kp DEL &kp BSPC
-&trans     &kp K_UNDO   &kp K_CUT    &kp K_COPY   &kp K_PASTE  &trans        &trans          &trans    &trans    &trans   &trans    &trans  &trans
-                        &trans       &trans       &trans       &trans        &trans  &trans  &trans    &trans    &trans   &trans
-                                                                                     &kp A      &kp B  &kp C &kp D  &kp E
+// TODO: Some binds are waiting for shifted keycode support.
+// ------------------------------------------------------------------------------------------------------------------------------------------
+// |       |   F1    |   F2    |    F3    |   F4      |   F5     |                  |   F6    |  F7    |  F8    |   F9    |   F10   |  F11  |
+// |       |         |         |          |           |  BSPC    |                  |  BSPC   | HOME   |  UP    |   END   |  PG_UP  |  F12  |
+// |       |         |         |          |           |  RET     |                  |  RET    | LEFT   | DOWN   |  RIGHT  |  PG_DN  |  DEL  |
+// |       | K_UNDO  |  K_CUT  |  K_COPY  | K_PASTE   |  ENTER   |       |  |       |  ENTER  |        |        |         |         |       |
+//                   |         |          |           |          | SPACE |  | SPACE |         |        |        |         |
+//                                                                      HAT:| ENTER |  LEFT   |  UP    |  DOWN  |  RIGHT  |
+            bindings = < 
+&none     &kp F1     &kp F2    &kp F3     &kp F4      &kp F5                        &kp F6    &kp F7   &kp F8   &kp F9    &kp F10   &kp F11
+&none     &none      &none     &none      &none       &kp BSPC                      &kp BSPC  &kp HOME &kp UP   &kp END   &kp PG_UP &kp F12
+&none     &none      &none     &none      &none       &kp RET                       &kp RET   &kp LEFT &kp DOWN &kp RIGHT &kp PG_DN &kp DEL
+&none     &kp K_UNDO &kp K_CUT &kp K_COPY &kp K_PASTE &kp ENTER  &none              &kp ENTER &none    &none    &none     &none     &none
+                     &trans    &trans     &trans      &trans     &trans   &trans    &trans    &trans   &trans   &trans
+                                                                          &kp ENTER &kp LEFT  &kp UP   &kp DOWN &kp RIGHT
             >;
 
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+            sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
         };
 
         adjust_layer {

--- a/config/sofle_ergomech.keymap
+++ b/config/sofle_ergomech.keymap
@@ -44,8 +44,8 @@
 &kp TAB   &kp APOS &kp COMMA &kp DOT  &kp P     &kp Y                            &kp F     &kp G     &kp C     &kp R    &kp L    &kp FSLH
 &kp LCTRL &kp A    &kp O     &kp E    &kp U     &kp I                            &kp D     &kp H     &kp T     &kp N    &kp S    &kp MINUS
 &kp LSHFT &kp SEMI &kp Q     &kp J    &kp K     &kp X      &kp ENTER             &kp B     &kp M     &kp W     &kp V    &kp V    &kp BSLH
-                   &kp LGUI  &kp LALT &mo LOWER &mo RAISE  &kp SPACE  &kp SPACE  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
-                                                                      &mkp LCLK  &kp DOWN  &kp UP    &kp RIGHT &kp LEFT
+                   &kp LGUI  &kp LALT &mo RAISE &mo LOWER  &kp SPACE  &kp SPACE  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
+                                                                      &mkp LCLK  &kp RIGHT &kp UP    &kp LEFT  &kp DOWN
             >;
 
             sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
@@ -66,7 +66,7 @@
 &trans     &kp LC(Y)     &none        &none         &none          &none                          &kp RET   &kp LEFT  &kp DOWN  &kp RIGHT &kp PG_DN &kp C_VOL_UP
 &trans     &kp LC(Z)     &kp LC(X)    &kp LC(C)     &kp LC(V)      &none        &none             &kp ENTER &mkp LCLK &mkp MCLK &mkp RCLK &none     &kp C_VOL_DN
                          &trans       &trans        &trans         &trans       &trans  &trans    &trans    &trans    &trans    &trans
-                                                                                        &mkp LCLK &kp DOWN  &kp UP    &kp RIGHT &kp LEFT
+                                                                                        &mkp LCLK &kp RIGHT &kp UP    &kp LEFT  &kp DOWN
             >;
 
             sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
@@ -88,7 +88,7 @@
 &trans    &kp LC(Y)  &none     &none      &none       &kp RET                       &kp RET   &kp LEFT  &kp DOWN  &kp RIGHT &kp PG_DN &kp DEL
 &trans    &kp LC(Z)  &kp LC(X) &kp LC(C)  &kp LC(V)   &kp ENTER  &none              &kp ENTER &mkp LCLK &mkp MCLK &mkp RCLK &none     &none
                      &trans    &trans     &trans      &trans     &trans   &trans    &trans    &trans    &trans    &trans
-                                                                          &mkp LCLK &kp DOWN  &kp UP    &kp RIGHT &kp LEFT
+                                                                          &mkp LCLK &kp RIGHT &kp UP    &kp LEFT  &kp DOWN
             >;
 
             sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
@@ -104,12 +104,12 @@
 //                    |         |         |         |         |         | |          |      |      |       |      |
 //                                                                    HAT:| LCLK     | DOWN |  UP  | RIGHT | LEFT |
             bindings = <
-&bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                                &none    &none  &none     &none     &none &none
-&ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                             &none    &none  &none     &none     &none &none
-&none             &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                       &none    &none  &none     &none     &none &none
-&none             &none           &none           &none           &none           &none            &rgb_ug RGB_TOG            &none    &none  &none     &none     &none &none
-                                  &none           &none           &none           &none            &none           &none      &none    &none  &none     &none
-                                                                                                                   &mkp LCLK  &kp DOWN &kp UP &kp RIGHT &kp LEFT
+&bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                                &none     &none     &none     &none     &none &none
+&ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                             &none     &none     &none     &none     &none &none
+&none             &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                       &none     &none     &none     &none     &none &none
+&none             &none           &none           &none           &none           &none            &rgb_ug RGB_TOG            &none     &none     &none     &none     &none &none
+                                  &none           &none           &none           &none            &none           &none      &none     &none     &none     &none
+                                                                                                                   &mkp LCLK  &kp RIGHT &kp UP    &kp LEFT  &kp DOWN
             >;
         };
 

--- a/config/sofle_ergomech.keymap
+++ b/config/sofle_ergomech.keymap
@@ -56,15 +56,15 @@
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 // | BTCLR |   BT1       |   BT2      |    BT3      |    BT4       |    BT5     |                 |         |         |         |  LBKT   |  RBKT   |  DEL   |
 // |       |   INS       |   BACK     |   FWD       |   CAPS       |            |                 |  BSPC   |  HOME   |  UP     |   END   |  PG_UP  | C_MUTE |
-// |       |   ALT       |   CTRL     |   SHIFT     |              |            |                 |  RET    |  LEFT   |  DOWN   |  RIGHT  |  PG_DN  |C_VOL_UP|
+// |       |   REDO      |            |             |              |            |                 |  RET    |  LEFT   |  DOWN   |  RIGHT  |  PG_DN  |C_VOL_UP|
 // |       |   UNDO      |   CUT      |   COPY      |   PASTE      |            |      |  |       |  ENTER  |  LCLK   |  MCLK   |  RCLK   |         |C_VOL_DN|
 //                       |            |             |              |            | SPACE|  | SPACE |         |         |         |         |
 //                                                                                    HAT:| LCLK  |  DOWN   |    UP   |  RIGHT  |  LEFT   |
             bindings = <
 &bt BT_CLR &bt BT_SEL 0  &bt BT_SEL 1 &bt BT_SEL 2  &bt BT_SEL 3   &bt BT_SEL 4                   &none     &none     &none     &kp LBKT  &kp RBKT  &kp DEL
 &trans     &kp INS       &mkp MB4     &mkp MB5      &kp CAPS       &none                          &kp BSPC  &kp HOME  &kp UP    &kp END   &kp PG_UP &kp C_MUTE
-&trans     &kp LALT      &kp LCTRL    &kp LSHFT     &none          &none                          &kp RET   &kp LEFT  &kp DOWN  &kp RIGHT &kp PG_DN &kp C_VOL_UP
-&trans     &kp C_AC_UNDO &kp C_AC_CUT &kp C_AC_COPY &kp C_AC_PASTE &none        &none             &kp ENTER &mkp LCLK &mkp MCLK &mkp RCLK &none     &kp C_VOL_DN
+&trans     &kp LC(Y)     &none        &none         &none          &none                          &kp RET   &kp LEFT  &kp DOWN  &kp RIGHT &kp PG_DN &kp C_VOL_UP
+&trans     &kp LC(Z)     &kp LC(X)    &kp LC(C)     &kp LC(V)      &none        &none             &kp ENTER &mkp LCLK &mkp MCLK &mkp RCLK &none     &kp C_VOL_DN
                          &trans       &trans        &trans         &trans       &trans  &trans    &trans    &trans    &trans    &trans
                                                                                         &mkp LCLK &kp DOWN  &kp UP    &kp RIGHT &kp LEFT
             >;
@@ -75,20 +75,20 @@
         raise_layer {
             label = "raise";
 // TODO: Some binds are waiting for shifted keycode support.
-// ------------------------------------------------------------------------------------------------------------------------------------------
-// |  ESC  |   F1    |   F2    |    F3    |   F4      |   F5     |                  |   F6    |  F7    |  F8     |   F9    |   F10   |  F11  |
-// |       |         |         |          |           |  BSPC    |                  |  BSPC   | HOME   |  UP     |   END   |  PG_UP  |  F12  |
-// |       |         |         |          |           |  RET     |                  |  RET    | LEFT   | DOWN    |  RIGHT  |  PG_DN  |  DEL  |
-// |       |         |         |          |           |  ENTER   |       |  |       |         |        |         |         |         |       |
-//                   |         |          |           |          | SPACE |  | SPACE |         |        |         |         |
-//                                                                      HAT:| LCLK  |  DOWN   |   UP   |  RIGHT  |  LEFT   |
-            bindings = <
-&kp ESC   &kp F1     &kp F2    &kp F3     &kp F4      &kp F5                        &kp F6    &kp F7   &kp F8    &kp F9    &kp F10   &kp F11
-&trans    &none      &trans    &trans     &none       &kp BSPC                      &kp BSPC  &kp HOME &kp UP    &kp END   &kp PG_UP &kp F12
-&trans    &none      &none     &none      &none       &kp RET                       &kp RET   &kp LEFT &kp DOWN  &kp RIGHT &kp PG_DN &kp DEL
-&trans    &trans     &trans    &trans     &trans      &kp ENTER  &none              &trans    &trans   &trans    &trans    &none     &none
-                     &trans    &trans     &trans      &trans     &trans   &trans    &trans    &trans   &trans    &trans
-                                                                          &mkp LCLK &kp DOWN  &kp UP   &kp RIGHT &kp LEFT
+// --------------------------------------------------------------------------------------------------------------------------------------------
+// |  ESC  |   F1    |   F2    |    F3    |   F4      |   F5     |                  |   F6    |  F7     |  F8     |   F9    |   F10   |  F11  |
+// |       |         |  BACK   |   FWD    |           |  BSPC    |                  |  BSPC   |  HOME   |  UP     |   END   |  PG_UP  |  F12  |
+// |       |  REDO   |         |          |           |  RET     |                  |  RET    |  LEFT   |  DOWN   |  RIGHT  |  PG_DN  |  DEL  |
+// |       |  UNDO   |   CUT   |   COPY   |   PASTE   |  ENTER   |       |  |       |  ENTER  |  LCLK   |  MCLK   |  RCLK   |         |       |
+//                   |         |          |           |          | SPACE |  | SPACE |         |         |         |         |
+//                                                                      HAT:| LCLK  |  DOWN   |   UP    |  RIGHT  |  LEFT   |
+            bindings = < 
+&kp ESC   &kp F1     &kp F2    &kp F3     &kp F4      &kp F5                        &kp F6    &kp F7    &kp F8    &kp F9    &kp F10   &kp F11
+&trans    &none      &mkp MB4  &mkp MB5   &none       &kp BSPC                      &kp BSPC  &kp HOME  &kp UP    &kp END   &kp PG_UP &kp F12
+&trans    &kp LC(Y)  &none     &none      &none       &kp RET                       &kp RET   &kp LEFT  &kp DOWN  &kp RIGHT &kp PG_DN &kp DEL
+&trans    &kp LC(Z)  &kp LC(X) &kp LC(C)  &kp LC(V)   &kp ENTER  &none              &kp ENTER &mkp LCLK &mkp MCLK &mkp RCLK &none     &none
+                     &trans    &trans     &trans      &trans     &trans   &trans    &trans    &trans    &trans    &trans
+                                                                          &mkp LCLK &kp DOWN  &kp UP    &kp RIGHT &kp LEFT
             >;
 
             sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;

--- a/config/sofle_ergomech.keymap
+++ b/config/sofle_ergomech.keymap
@@ -9,11 +9,10 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/rgb.h>
 #include <dt-bindings/zmk/ext_power.h>
-//#include <dt-bindings/zmk/mouse.h>
 
 #define BASE 0
-#define RAISE 1
-#define LOWER 2
+#define LOWER 1
+#define RAISE 2
 #define ADJUST 3
 
 / {
@@ -32,84 +31,80 @@
 
         default_layer {
             label = "default";
-// ---------------------------------------------------------------------------------------------------------------------------------------
-// |   `   |   1   |    2    |   3    |   4     |   5      |                     |   6     |    7    |   8     |  9     |   0    |   =   |
-// |  TAB  |   '   |    ,    |   .    |   P     |   Y      |                     |   F     |    G    |   C     |  R     |   L    |   /   |
-// |  CTRL |   A   |    O    |   E    |   U     |   I      |                     |   D     |    H    |   T     |  N     |   S    |   -   |
-// | SHIFT |   ;   |    Q    |   J    |   K     |   X      |  ENTER  |  |        |   B     |    M    |   W     |  V     |   V    |   \   |
-//                 |   GUI   |  ALT   |  LOWER  |  RAISE   |  SPACE  |  |  SPACE |  LEFT   |    UP   |   DOWN  | RIGHT  |
-//                                                                  HAT:|  ENTER |  LEFT   |    UP   |   DOWN  | RIGHT  |
+// ------------------------------------------------------------------------------------------------------------
+// |   `   |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   |       |
+// |  ESC  |  Q  |  W  |  E   |  R   |  T   |                   |  Y   |  U    |  I    |  O   |   P   | BKSPC |
+// |  TAB  |  A  |  S  |  D   |  F   |  G   |                   |  H   |  J    |  K    |  L   |   ;   |   '   |
+// | SHIFT |  Z  |  X  |  C   |  V   |  B   |  MUTE  |  |       |  N   |  M    |  ,    |  .   |   /   | SHIFT |
+//               | GUI | ALT  | CTRL | LOWER|  ENTER |  | SPACE | RAISE| CTRL  | ALT   | GUI  |
             bindings = <
-&kp GRAVE &kp N1   &kp N2    &kp N3   &kp N4    &kp N5                           &kp N6    &kp N7    &kp N8    &kp N9   &kp N0   &kp EQUAL
-&kp TAB   &kp APOS &kp COMMA &kp DOT  &kp P     &kp Y                            &kp F     &kp G     &kp C     &kp R    &kp L    &kp FSLH
-&kp CTRL  &kp A    &kp O     &kp E    &kp U     &kp I                            &kp D     &kp H     &kp T     &kp N    &kp S    &kp MINUS
-&kp LSHFT &kp SEMI &kp Q     &kp J    &kp K     &kp X      &kp ENTER             &kp B     &kp M     &kp W     &kp V    &kp V    &kp BSLH
-                   &kp LGUI  &kp LALT &mo LOWER &mo RAISE  &kp SPACE  &kp SPACE  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
-                                                                      &kp ENTER  &kp LEFT  &kp UP    &kp DOWN  &kp RIGHT
+&kp GRAVE &kp N1 &kp N2   &kp N3   &kp N4    &kp N5                           &kp N6 &kp N7    &kp N8    &kp N9   &kp N0   &none
+&kp ESC   &kp Q  &kp W    &kp E    &kp R     &kp T                            &kp Y  &kp U     &kp I     &kp O    &kp P    &kp BSPC
+&kp TAB   &kp A  &kp S    &kp D    &kp F     &kp G                            &kp H  &kp J     &kp K     &kp L    &kp SEMI &kp SQT
+&kp LSHFT &kp Z  &kp X    &kp C    &kp V     &kp B      &kp C_MUTE            &kp N  &kp M     &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
+                 &kp LGUI &kp LALT &kp LCTRL &mo LOWER  &kp RET    &kp SPACE  &mo RAISE  &kp RCTRL &kp RALT  &kp RGUI
+                                                                   &kp A      &kp B  &kp C &kp D  &kp E
             >;
 
-            sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
-        };
-
-        raise_layer {
-            label = "raise";
-// TODO: Some binds are waiting for shifted keycode support.
-// ------------------------------------------------------------------------------------------------------------------------------------------
-// |       |   F1    |   F2    |    F3    |   F4      |   F5     |                  |   F6    |  F7    |  F8    |   F9    |   F10   |  F11  |
-// |       |         |         |          |           |  BSPC    |                  |  BSPC   | HOME   |  UP    |   END   |  PG_UP  |  F12  |
-// |       |         |         |          |           |  RET     |                  |  RET    | LEFT   | DOWN   |  RIGHT  |  PG_DN  |  DEL  |
-// |       | K_UNDO  |  K_CUT  |  K_COPY  | K_PASTE   |  ENTER   |       |  |       |  ENTER  |        |        |         |         |       |
-//                   |         |          |           |          | SPACE |  | SPACE |         |        |        |         |
-//                                                                      HAT:| ENTER |  LEFT   |  UP    |  DOWN  |  RIGHT  |
-            bindings = < 
-&none     &kp F1     &kp F2    &kp F3     &kp F4      &kp F5                        &kp F6    &kp F7   &kp F8   &kp F9    &kp F10   &kp F11
-&none     &none      &none     &none      &none       &kp BSPC                      &kp BSPC  &kp HOME &kp UP   &kp END   &kp PG_UP &kp F12
-&none     &none      &none     &none      &none       &kp RET                       &kp RET   &kp LEFT &kp DOWN &kp RIGHT &kp PG_DN &kp DEL
-&none     &kp K_UNDO &kp K_CUT &kp K_COPY &kp K_PASTE &kp ENTER  &none              &kp ENTER &none    &none    &none     &none     &none
-                     &trans    &trans     &trans      &trans     &trans   &trans    &trans    &trans   &trans   &trans
-                                                                          &kp ENTER &kp LEFT  &kp UP   &kp DOWN &kp RIGHT
-            >;
-
-            sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
+            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
         };
 
         lower_layer {
             label = "lower";
-// -----------------------------------------------------------------------------------------------------------------------------------------------------
-// | BTCLR |   BT1      |   BT2      |    BT3     |    BT4     |    BT5     |                 |         |         |        |  LBKT   | RBKT   |  DEL   |
-// |       |   INS      |   PSCR     |   GUI      |   CAPS     |            |                 |  BSPC   |  HOME   |  UP    |   END   | PG_UP  | C_MUTE |
-// |       |   ALT      |   CTRL     |   SHIFT    |            |            |                 |  RET    |  LEFT   | DOWN   |  RIGHT  | PG_DN  |C_VOL_UP|
-// |       |   UNDO     |   CUT      |   COPY     |   PASTE    |            |      |  |       |  ENTER  |         |        |         |        |C_VOL_DN|
-//                      |            |            |            |            | SPACE|  | SPACE |         |         |        |         |
-//                                                                                HAT:| ENTER |  LEFT   |   UP    |  DOWN  |  RIGHT  |
-            bindings = <   
-&bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4                   &none     &none     &none    &kp LBKT  &kp RBKT &kp DEL
-&none      &kp INS      &kp PSCRN    &kp K_CMENU  &CAPS        &none                          &kp PG_UP &trans    &trans   &trans    &trans   &kp C_MUTE
-&none      &kp LALT     &kp LCTRL    &kp LSHFT    &none        &none                          &kp PG_DN &trans    &trans   &trans    &trans   &kp C_VOL_UP
-&none      &kp K_UNDO   &kp K_CUT    &kp K_COPY   &kp K_PASTE  &none        &none             &trans    &none     &none    &none     &none    &kp C_VOL_DN
-                        &trans       &trans       &trans       &trans       &trans  &trans    &trans    &none     &none    &none 
-                                                                                    &kp ENTER &kp LEFT  &kp UP    &kp DOWN &kp RIGHT
+// TODO: Some binds are waiting for shifted keycode support.
+// ------------------------------------------------------------------------------------------------------------
+// |       |  F1 |  F2 |  F3  |  F4  |  F5  |                   |  F6  |  F7   |  F8   |  F9  |  F10  |  F11  |
+// |   `   |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   |  F12  |
+// |       |  !  |  @  |  #   |  $   |  %   |                   |  ^   |  &    |  *    |  (   |   )   |   |   |
+// |       |  =  |  -  |  +   |  {   |  }   |        |  |       |  [   |  ]    |  ;    |  :   |   \   |       |
+//               |     |      |      |      |        |  |       |      |       |       |      |
+            bindings = <
+&trans    &kp F1    &kp F2    &kp F3      &kp F4    &kp F5                    &kp F6    &kp F7   &kp F8          &kp F9    &kp F10   &kp F11
+&kp GRAVE &kp N1    &kp N2    &kp N3      &kp N4    &kp N5                    &kp N6    &kp N7   &kp N8          &kp N9    &kp N0    &kp F12
+&trans    &kp EXCL  &kp AT    &kp HASH    &kp DLLR  &kp PRCNT                 &kp CARET &kp AMPS &kp KP_MULTIPLY &kp LPAR  &kp RPAR  &kp PIPE
+&trans    &kp EQUAL &kp MINUS &kp KP_PLUS &kp LBRC  &kp RBRC   &trans         &kp LBKT  &kp RBKT &kp SEMI        &kp COLON &kp BSLH  &trans
+                    &trans    &trans      &trans    &trans     &trans &trans  &trans    &trans   &trans          &trans
+                                                                      &kp A      &kp B  &kp C &kp D  &kp E
             >;
 
-            sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp PG_UP PG_DN>;
+            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+        };
+
+        raise_layer {
+            label = "raise";
+// ------------------------------------------------------------------------------------------------------------
+// | BTCLR | BT1  | BT2  |  BT3  |  BT4  |  BT5 |                |      |      |       |      |       |       |
+// |       | INS  | PSCR | GUI   |       |      |                | PGUP |      |   ^   |      |       |       |
+// |       | ALT  | CTRL | SHIFT |       | CAPS |                | PGDN |   <- |   v   |  ->  |  DEL  | BKSPC |
+// |       | UNDO | CUT  | COPY  | PASTE |      |      |  |      |      |      |       |      |       |       |
+//                |      |       |       |      |      |  |      |      |      |       |      |
+            bindings = <
+&bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4                  &trans    &trans    &trans   &trans    &trans  &trans
+&trans     &kp INS      &kp PSCRN    &kp K_CMENU  &trans       &trans                        &kp PG_UP &trans    &kp UP   &trans    &kp N0  &trans
+&trans     &kp LALT     &kp LCTRL    &kp LSHFT    &trans       &kp CLCK                      &kp PG_DN &kp LEFT  &kp DOWN &kp RIGHT &kp DEL &kp BSPC
+&trans     &kp K_UNDO   &kp K_CUT    &kp K_COPY   &kp K_PASTE  &trans        &trans          &trans    &trans    &trans   &trans    &trans  &trans
+                        &trans       &trans       &trans       &trans        &trans  &trans  &trans    &trans    &trans   &trans
+                                                                                     &kp A      &kp B  &kp C &kp D  &kp E
+            >;
+
+            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
         };
 
         adjust_layer {
+// ----------------------------------------------------------------------------------------------------------------------------
+// | BTCLR  |  BT1    |  BT2    |   BT3   |   BT4   |   BT5   |                  |      |      |       |      |       |       |
+// | EXTPWR | RGB_HUD | RGB_HUI | RGB_SAD | RGB_SAI | RGB_EFF |                  |      |      |       |      |       |       |
+// |        | RGB_BRD | RGB_BRI |         |         |         |                  |      |      |       |      |       |       |
+// |        |         |         |         |         |         | RGB_TOG | |      |      |      |       |      |       |       |
+//                    |         |         |         |         |         | |      |      |      |       |      |
             label = "adjust";
-// --------------------------------------------------------------------------------------------------------------------------------
-// | BTCLR  |  BT1    |  BT2    |   BT3   |   BT4   |   BT5   |                      |      |      |       |      |       |       |
-// | EXTPWR | RGB_HUD | RGB_HUI | RGB_SAD | RGB_SAI | RGB_EFF |                      |      |      |       |      |       |       |
-// |        | RGB_BRD | RGB_BRI |         |         |         |                      |      |      |       |      |       |       |
-// |        |         |         |         |         |         | RGB_TOG | |          |      |      |       |      |       |       |
-//                    |         |         |         |         |         | |          |      |      |       |      |
-//                                                                    HAT:| ENTER    | LEFT |  UP  |  DOWN | RIGHT|
             bindings = <
-&bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                                &none    &none  &none    &none     &none &none
-&ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                             &none    &none  &none    &none     &none &none
-&none             &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                       &none    &none  &none    &none     &none &none
-&none             &none           &none           &none           &none           &none            &rgb_ug RGB_TOG            &none    &none  &none    &none     &none &none
-                                  &none           &none           &none           &none            &none           &none      &none    &none  &none    &none
-                                                                                                                   &kp ENTER  &kp LEFT &kp UP &kp DOWN &kp RIGHT
+&bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                            &none &none &none &none &none &none
+&ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                         &none &none &none &none &none &none
+&none             &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                   &none &none &none &none &none &none
+&none             &none           &none           &none           &none           &none            &rgb_ug RGB_TOG        &none &none &none &none &none &none
+                                  &none           &none           &none           &none            &none           &none  &none &none &none &none
+                                                                                                                    &kp A      &kp B  &kp C &kp D  &kp E
             >;
         };
 


### PR DESCRIPTION
This update contains the following changes:

- Base keymap changed to DVORAK
- Inline cursor controls added on RAISE and LOWER layers
- Tophat changed to use directional arrows
- Inline ESC/undo/redo/cut/copy/paste added on RAISE and LOWER layers
- Other minor tweaks and changes